### PR TITLE
feat: return empty object when no release was found

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,12 @@ module.exports = function getLatestRelease(pluginConfig, config, callback) {
         user: githubRepo[0],
         repo: githubRepo[1],
     }, (err, latestRelease) => {
+        const isNotFound = err && (err.code === 404 || /not found/i.test(err.message))
+
+        if (isNotFound) {
+            return callback(null, {})
+        }
+
         if (err) {
             return callback(err);
         }


### PR DESCRIPTION
Let semantic-release figure out a new version whenever we detect that there is no release in GitHub.

Same behaviour as [last-release-npm](https://github.com/semantic-release/last-release-npm/blob/next/src/index.js#L15-L20)